### PR TITLE
Bump javagi version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.1.20"
 compose = "1.7.3"
-javagi = "0.12.1"
+javagi = "0.12.2"
 dokka = "2.0.0"
 kotlin-logging = "7.0.7"
 slf4j = "2.0.17"


### PR DESCRIPTION
An incorrect GIR file had been used, version 0.12.2 fixes this.
(I noticed ToggleGroup was missing, it's now present)