### PR TITLE
Add Grouping to CheckButton with an example

### DIFF
--- a/src/main/kotlin/io/github/compose4gtk/gtk/components/CheckButton.kt
+++ b/src/main/kotlin/io/github/compose4gtk/gtk/components/CheckButton.kt
@@ -56,7 +56,6 @@ private fun BaseCheckButton(
                     cb.setGroup(groupLeaderState.value)
                 } else {
                     groupLeaderState.value = cb
-                    cb.setGroup(cb)
                 }
             }
             GtkCheckButton(cb)

--- a/src/main/kotlin/io/github/compose4gtk/gtk/components/CheckButton.kt
+++ b/src/main/kotlin/io/github/compose4gtk/gtk/components/CheckButton.kt
@@ -93,7 +93,6 @@ private fun BaseCheckButton(
  * @param active Whether the check button is currently active.
  * @param inconsistent Whether the button should display an inconsistent (partially active) state.
  * @param useUnderline Whether to use an underscore in the label for mnemonic activation.
- * @param enabled Whether the check button is enabled for interaction.
  * @param onToggle Callback invoked when the check button is toggled.
  */
 @Composable
@@ -102,7 +101,6 @@ fun CheckButton(
     active: Boolean,
     inconsistent: Boolean = false,
     useUnderline: Boolean = false,
-    enabled: Boolean = true,
     onToggle: () -> Unit,
 ) {
     BaseCheckButton(

--- a/src/main/kotlin/io/github/compose4gtk/gtk/components/CheckButton.kt
+++ b/src/main/kotlin/io/github/compose4gtk/gtk/components/CheckButton.kt
@@ -46,16 +46,16 @@ private fun BaseCheckButton(
     onToggle: () -> Unit,
 ) {
     var pendingChange by remember { mutableStateOf(0) }
-    val groupLeader = LocalCheckButtonGroupLeader.current
+    val groupLeaderState = LocalCheckButtonGroupLeader.current
 
     ComposeNode<GtkCheckButton, GtkApplier>(
         factory = {
             val cb = CheckButton.builder().build()
-            if (groupLeader != null) {
-                if (groupLeader.value != null) {
-                    cb.setGroup(groupLeader.value)
+            if (groupLeaderState != null) {
+                if (groupLeaderState.value != null) {
+                    cb.setGroup(groupLeaderState.value)
                 } else {
-                    groupLeader.value = cb
+                    groupLeaderState.value = cb
                     cb.setGroup(cb)
                 }
             }

--- a/src/main/kotlin/io/github/compose4gtk/gtk/components/CheckButton.kt
+++ b/src/main/kotlin/io/github/compose4gtk/gtk/components/CheckButton.kt
@@ -18,6 +18,7 @@ private class GtkCheckButton(gObject: CheckButton) : SingleChildComposeNode<Chec
  *
  * @param modifier The modifier to apply to the widget.
  * @param active Whether the check button is currently active.
+ * @param group Optional group for radio-style buttons.
  * @param inconsistent Whether the button should display an inconsistent (partially active) state.
  * @param label Optional text label.
  * @param useUnderline Whether to use an underscore in the label for mnemonic activation.
@@ -28,6 +29,7 @@ private class GtkCheckButton(gObject: CheckButton) : SingleChildComposeNode<Chec
 private fun BaseCheckButton(
     modifier: Modifier = Modifier,
     active: Boolean,
+    group: CheckButton? = null,
     inconsistent: Boolean = false,
     label: String? = null,
     useUnderline: Boolean = false,
@@ -46,6 +48,7 @@ private fun BaseCheckButton(
                 this.widget.active = active
                 this.toggled?.unblock()
             }
+            set(group) { this.widget.setGroup(group) }
             set(inconsistent) { this.widget.inconsistent = it }
             set(label) { this.widget.label = it }
             set(useUnderline) { this.widget.useUnderline = it }
@@ -69,6 +72,7 @@ private fun BaseCheckButton(
  *
  * @param modifier The modifier to apply to the widget.
  * @param active Whether the check button is currently active.
+ * @param group Optional group for radio-style buttons.
  * @param inconsistent Whether the button should display an inconsistent (partially active) state.
  * @param useUnderline Whether to use an underscore in the label for mnemonic activation.
  * @param enabled Whether the check button is enabled for interaction.
@@ -78,6 +82,7 @@ private fun BaseCheckButton(
 fun CheckButton(
     modifier: Modifier = Modifier,
     active: Boolean,
+    group: CheckButton? = null,
     inconsistent: Boolean = false,
     useUnderline: Boolean = false,
     enabled: Boolean = true,
@@ -86,6 +91,7 @@ fun CheckButton(
     BaseCheckButton(
         modifier = modifier,
         active = active,
+        group = group,
         inconsistent = inconsistent,
         useUnderline = useUnderline,
         onToggle = onToggle,
@@ -97,6 +103,7 @@ fun CheckButton(
  *
  * @param modifier The modifier to apply to the widget.
  * @param active Whether the check button is currently active.
+ * @param group Optional group for radio-style buttons.
  * @param label Text label.
  * @param inconsistent Whether the button should display an inconsistent (partially active) state.
  * @param useUnderline Whether to use an underscore in the label for mnemonic activation.
@@ -106,6 +113,7 @@ fun CheckButton(
 fun CheckButton(
     modifier: Modifier = Modifier,
     active: Boolean,
+    group: CheckButton? = null,
     label: String,
     inconsistent: Boolean = false,
     useUnderline: Boolean = false,
@@ -114,6 +122,7 @@ fun CheckButton(
     BaseCheckButton(
         modifier = modifier,
         active = active,
+        group = group,
         inconsistent = inconsistent,
         label = label,
         useUnderline = useUnderline,
@@ -126,6 +135,7 @@ fun CheckButton(
  *
  * @param modifier The modifier to apply to the widget.
  * @param active Whether the check button is currently active.
+ * @param group Optional group for radio-style buttons.
  * @param child Custom composable content.
  * @param inconsistent Whether the button should display an inconsistent (partially active) state.
  * @param useUnderline Whether to use an underscore in the label for mnemonic activation.
@@ -135,6 +145,7 @@ fun CheckButton(
 fun CheckButton(
     modifier: Modifier = Modifier,
     active: Boolean,
+    group: CheckButton? = null,
     child: @Composable () -> Unit,
     inconsistent: Boolean = false,
     useUnderline: Boolean = false,
@@ -143,6 +154,7 @@ fun CheckButton(
     BaseCheckButton(
         modifier = modifier,
         active = active,
+        group = group,
         inconsistent = inconsistent,
         child = child,
         useUnderline = useUnderline,

--- a/src/test/kotlin/CheckButton.kt
+++ b/src/test/kotlin/CheckButton.kt
@@ -25,8 +25,8 @@ fun main(args: Array<String>) {
 
                             CheckButton(
                                 modifier = Modifier.alignment(Align.START), active = isChecked, label = "Change me!"
-                            ) {
-                                isChecked = !isChecked
+                            ) { active ->
+                                isChecked = active
                             }
 
                             CheckButton(
@@ -52,8 +52,8 @@ fun main(args: Array<String>) {
                                         Label("Custom child")
                                     }
                                 },
-                            ) {
-                                isChecked = !isChecked
+                            ) {active ->
+                                isChecked = active
                             }
 
                             CheckButton(
@@ -78,7 +78,7 @@ fun main(args: Array<String>) {
                                 active = allChecked(),
                                 inconsistent = someChecked() && !allChecked(),
                                 label = "Select all"
-                            ) {
+                            ) {active ->
                                 val newState = !someChecked()
                                 for (i in checkedStates.indices) {
                                     checkedStates[i] = newState
@@ -90,8 +90,8 @@ fun main(args: Array<String>) {
                                     modifier = Modifier.alignment(Align.START),
                                     active = isChecked,
                                     label = "Option ${index + 1}"
-                                ) {
-                                    checkedStates[index] = !checkedStates[index]
+                                ) { active ->
+                                    checkedStates[index] = active
                                 }
                             }
                         }

--- a/src/test/kotlin/CheckButtonGroup.kt
+++ b/src/test/kotlin/CheckButtonGroup.kt
@@ -1,5 +1,7 @@
-import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import io.github.compose4gtk.adw.application
 import io.github.compose4gtk.adw.components.ApplicationWindow
 import io.github.compose4gtk.adw.components.HeaderBar
@@ -20,16 +22,17 @@ fun main(args: Array<String>) {
 
                 StatusPage(title = "Radio Buttons", description = "Check buttons grouped to make radio-style buttons") {
                     VerticalBox {
-                        val checkedStates = remember { mutableStateListOf(false, false, false, false, false) }
+                        val radioOptions = listOf("Calls", "Missed", "Friends")
+                        var selectedOption by remember { mutableStateOf(radioOptions[0]) }
 
                         CheckButtonGroup {
-                            checkedStates.forEachIndexed { index, isChecked ->
+                            radioOptions.forEach { text ->
                                 CheckButton(
                                     modifier = Modifier.alignment(Align.START),
-                                    active = isChecked,
-                                    label = "Option $index ($isChecked)",
+                                    active = (text == selectedOption),
+                                    label = text,
                                 ) {
-                                    checkedStates[index] = !checkedStates[index]
+                                    selectedOption = text
                                 }
                             }
                         }

--- a/src/test/kotlin/CheckButtonGroup.kt
+++ b/src/test/kotlin/CheckButtonGroup.kt
@@ -1,18 +1,12 @@
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import io.github.compose4gtk.adw.application
 import io.github.compose4gtk.adw.components.ApplicationWindow
 import io.github.compose4gtk.adw.components.HeaderBar
 import io.github.compose4gtk.adw.components.StatusPage
-import io.github.compose4gtk.gtk.components.CheckButton
-import io.github.compose4gtk.gtk.components.CheckButtonGroup
+import io.github.compose4gtk.gtk.components.RadioButton
 import io.github.compose4gtk.gtk.components.VerticalBox
+import io.github.compose4gtk.gtk.components.rememberRadioGroupState
 import io.github.compose4gtk.modifier.Modifier
-import io.github.compose4gtk.modifier.alignment
 import io.github.compose4gtk.modifier.cssClasses
-import org.gnome.gtk.Align
 
 fun main(args: Array<String>) {
     application("my.example.hello-app", args) {
@@ -23,17 +17,15 @@ fun main(args: Array<String>) {
                 StatusPage(title = "Radio Buttons", description = "Check buttons grouped to make radio-style buttons") {
                     VerticalBox {
                         val radioOptions = listOf("Calls", "Missed", "Friends")
-                        var selectedOption by remember { mutableStateOf(radioOptions[0]) }
+                        val radioState = rememberRadioGroupState(radioOptions.first())
 
-                        CheckButtonGroup {
-                            radioOptions.forEach { text ->
-                                CheckButton(
-                                    modifier = Modifier.alignment(Align.START),
-                                    active = (text == selectedOption),
-                                    label = text,
-                                ) {
-                                    selectedOption = text
-                                }
+                        radioOptions.forEach { text ->
+                            RadioButton(
+                                item = text,
+                                state = radioState,
+                                label = text
+                            ) {
+                                radioState.selected = text
                             }
                         }
                     }

--- a/src/test/kotlin/CheckButtonGroup.kt
+++ b/src/test/kotlin/CheckButtonGroup.kt
@@ -1,32 +1,41 @@
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import io.github.compose4gtk.adw.application
 import io.github.compose4gtk.adw.components.ApplicationWindow
 import io.github.compose4gtk.adw.components.HeaderBar
 import io.github.compose4gtk.adw.components.StatusPage
+import io.github.compose4gtk.gtk.components.Button
 import io.github.compose4gtk.gtk.components.RadioButton
 import io.github.compose4gtk.gtk.components.VerticalBox
 import io.github.compose4gtk.gtk.components.rememberRadioGroupState
 import io.github.compose4gtk.modifier.Modifier
 import io.github.compose4gtk.modifier.cssClasses
 
+private val OPTIONS = listOf("Calls", "Missed", "Friends", "Inconsistent")
+
 fun main(args: Array<String>) {
     application("my.example.hello-app", args) {
         ApplicationWindow(title = "Radio Buttons", onClose = ::exitApplication) {
             VerticalBox {
                 HeaderBar(modifier = Modifier.cssClasses("flat"))
-
                 StatusPage(title = "Radio Buttons", description = "Check buttons grouped to make radio-style buttons") {
                     VerticalBox {
-                        val radioOptions = listOf("Calls", "Missed", "Friends")
-                        val radioState = rememberRadioGroupState(radioOptions.first())
+                        var selection: String? by remember { mutableStateOf(null) }
+                        val radioState = rememberRadioGroupState()
 
-                        radioOptions.forEach { text ->
+                        OPTIONS.forEach { option ->
                             RadioButton(
-                                item = text,
+                                active = option == selection,
+                                inconsistent = option == selection && option == "Inconsistent",
                                 state = radioState,
-                                label = text
-                            ) {
-                                radioState.selected = text
-                            }
+                                label = option,
+                            ) { selection = option }
+                        }
+
+                        Button("Clear") {
+                            selection = null
                         }
                     }
                 }

--- a/src/test/kotlin/CheckButtonGroup.kt
+++ b/src/test/kotlin/CheckButtonGroup.kt
@@ -1,0 +1,40 @@
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import io.github.compose4gtk.adw.application
+import io.github.compose4gtk.adw.components.ApplicationWindow
+import io.github.compose4gtk.adw.components.HeaderBar
+import io.github.compose4gtk.adw.components.StatusPage
+import io.github.compose4gtk.gtk.components.CheckButton
+import io.github.compose4gtk.gtk.components.VerticalBox
+import io.github.compose4gtk.modifier.Modifier
+import io.github.compose4gtk.modifier.alignment
+import io.github.compose4gtk.modifier.cssClasses
+import org.gnome.gtk.Align
+
+fun main(args: Array<String>) {
+    application("my.example.hello-app", args) {
+        ApplicationWindow(title = "Radio Buttons", onClose = ::exitApplication) {
+            VerticalBox {
+                HeaderBar(modifier = Modifier.cssClasses("flat"))
+
+                StatusPage(title = "Radio Buttons", description = "Check buttons grouped to make radio-style buttons") {
+                    VerticalBox {
+                        val checkedStates = remember { mutableStateListOf(false, false, false, false, false) }
+                        val radioGroup = org.gnome.gtk.CheckButton()
+
+                        checkedStates.forEachIndexed { index, isChecked ->
+                            CheckButton(
+                                modifier = Modifier.alignment(Align.START),
+                                active = isChecked,
+                                label = "Option $index",
+                                group = radioGroup
+                            ) {
+                                checkedStates[index] = !checkedStates[index]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/CheckButtonGroup.kt
+++ b/src/test/kotlin/CheckButtonGroup.kt
@@ -5,6 +5,7 @@ import io.github.compose4gtk.adw.components.ApplicationWindow
 import io.github.compose4gtk.adw.components.HeaderBar
 import io.github.compose4gtk.adw.components.StatusPage
 import io.github.compose4gtk.gtk.components.CheckButton
+import io.github.compose4gtk.gtk.components.CheckButtonGroup
 import io.github.compose4gtk.gtk.components.VerticalBox
 import io.github.compose4gtk.modifier.Modifier
 import io.github.compose4gtk.modifier.alignment
@@ -20,16 +21,16 @@ fun main(args: Array<String>) {
                 StatusPage(title = "Radio Buttons", description = "Check buttons grouped to make radio-style buttons") {
                     VerticalBox {
                         val checkedStates = remember { mutableStateListOf(false, false, false, false, false) }
-                        val radioGroup = org.gnome.gtk.CheckButton()
 
-                        checkedStates.forEachIndexed { index, isChecked ->
-                            CheckButton(
-                                modifier = Modifier.alignment(Align.START),
-                                active = isChecked,
-                                label = "Option $index",
-                                group = radioGroup
-                            ) {
-                                checkedStates[index] = !checkedStates[index]
+                        CheckButtonGroup {
+                            checkedStates.forEachIndexed { index, isChecked ->
+                                CheckButton(
+                                    modifier = Modifier.alignment(Align.START),
+                                    active = isChecked,
+                                    label = "Option $index ($isChecked)",
+                                ) {
+                                    checkedStates[index] = !checkedStates[index]
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
I don't really like the fact that we have to create a org.gnome.gtk.CheckButton in order to group them. If you have a better idea please let me know, but for now I think this works.


https://github.com/user-attachments/assets/1fda5187-76cc-4c36-a389-caafd2f88efc

