### PR TITLE
ListView simplify selection models usage

### DIFF
--- a/src/main/kotlin/io/github/compose4gtk/gtk/components/ListView.kt
+++ b/src/main/kotlin/io/github/compose4gtk/gtk/components/ListView.kt
@@ -4,12 +4,10 @@ import androidx.compose.runtime.*
 import io.github.jwharm.javagi.gio.ListIndexModel
 import io.github.compose4gtk.*
 import io.github.compose4gtk.modifier.Modifier
+import org.gnome.gio.ListModel
 import org.gnome.gio.ListStore
 import org.gnome.gobject.GObject
-import org.gnome.gtk.ListItem
-import org.gnome.gtk.NoSelection
-import org.gnome.gtk.SelectionModel
-import org.gnome.gtk.SignalListItemFactory
+import org.gnome.gtk.*
 import org.gnome.gtk.ListView as GTKListView
 
 /**
@@ -99,6 +97,75 @@ fun <T : GObject> ListView(
             set(model) { this.widget.model = it }
         },
     )
+}
+
+@Composable
+fun <Item : GObject> rememberNoSelectionModel(
+    vararg keys: Any,
+    count: Int,
+    itemFactory: (index: Int) -> Item,
+): SelectionModel<Item> =
+    rememberSelectionModel(
+        keys = keys,
+        count = count,
+        itemFactory = itemFactory,
+        selectionModelFactory = { model -> NoSelection(model) },
+    )
+
+@Composable
+fun <Item : GObject> rememberSingleSelectionModel(
+    vararg keys: Any,
+    count: Int,
+    itemFactory: (index: Int) -> Item,
+): SelectionModel<Item> =
+    rememberSelectionModel(
+        keys = keys,
+        count = count,
+        itemFactory = itemFactory,
+        selectionModelFactory = { model -> SingleSelection(model) },
+    )
+
+@Composable
+fun <Item : GObject> rememberMultiSelectionModel(
+    vararg keys: Any,
+    count: Int,
+    itemFactory: (index: Int) -> Item,
+): SelectionModel<Item> =
+    rememberSelectionModel(
+        keys = keys,
+        count = count,
+        itemFactory = itemFactory,
+        selectionModelFactory = { model -> MultiSelection(model) },
+    )
+
+@Composable
+private fun <Item : GObject, Model : SelectionModel<Item>> rememberSelectionModel(
+    vararg keys: Any,
+    count: Int,
+    itemFactory: (index: Int) -> Item,
+    selectionModelFactory: (model: ListModel<Item>) -> Model,
+): SelectionModel<Item> {
+    val model = remember { ListStore<Item>() }
+
+    remember(*keys, count) {
+        while (model.size > count) {
+            model.removeLast()
+        }
+    }
+
+    remember(*keys, itemFactory) {
+        for (i in 0 until model.size) {
+            model[i] = itemFactory(i)
+        }
+    }
+
+    remember(count) {
+        while (model.size < count) {
+            model.append(itemFactory(model.size))
+        }
+    }
+
+    return remember { selectionModelFactory(model) }
 }
 
 /**

--- a/src/test/kotlin/ListView.kt
+++ b/src/test/kotlin/ListView.kt
@@ -5,16 +5,14 @@ import io.github.compose4gtk.adw.components.HeaderBar
 import io.github.compose4gtk.gtk.components.*
 import io.github.compose4gtk.modifier.Modifier
 import io.github.compose4gtk.modifier.expand
-import org.gnome.gio.ListStore
 import org.gnome.gobject.GObject
-import org.gnome.gtk.MultiSelection
-import org.gnome.gtk.SelectionModel
 
 fun main(args: Array<String>) {
     application("my.example.hello-app", args) {
         ApplicationWindow("Test", onClose = ::exitApplication, defaultWidth = 800, defaultHeight = 800) {
             VerticalBox {
                 HeaderBar(title = { Label("ListView") })
+                var itemVersion by remember { mutableStateOf(0) }
                 var itemSize by remember { mutableStateOf(5) }
                 var show by remember { mutableStateOf(true) }
                 HorizontalBox(Modifier.expand()) {
@@ -25,7 +23,9 @@ fun main(args: Array<String>) {
                             }
                         }
                         Panel("Custom model (multiple selection)") {
-                            val model = createModel(itemSize)
+                            val model = rememberMultiSelectionModel(itemVersion, count = itemSize) { index ->
+                                CustomItem("Custom item version $itemVersion #${index}")
+                            }
                             ListView(model) { customItem ->
                                 Label(customItem.name)
                             }
@@ -47,6 +47,9 @@ fun main(args: Array<String>) {
                 Button("Remove all items") {
                     itemSize = 0
                 }
+                Button("Increase item version") {
+                    itemVersion++
+                }
                 Button(if(show)"hide" else "show") {
                     show = !show
                 }
@@ -56,18 +59,6 @@ fun main(args: Array<String>) {
 }
 
 private class CustomItem(val name: String) : GObject()
-
-@Composable
-private fun createModel(count: Int): SelectionModel<CustomItem> {
-    val model = remember { ListStore<CustomItem>() }
-    while (model.size > count) {
-        model.removeLast()
-    }
-    while (model.size < count) {
-        model.append(CustomItem("Custom item #${model.size}"))
-    }
-    return remember { MultiSelection(model) }
-}
 
 @Composable
 private fun Panel(title: String, content: @Composable () -> Unit) {


### PR DESCRIPTION
* share selection model for simpler usage (using generics for Item type)
* allow creation of the following selection models: no selection / single / multiple
* added optional keys to the remember, in case the item factory uses a mutable value

***Note**: a simpler alternative for keys would be to just have the item factory be declared in a `derivedStateOf`. This make keys useless and would leave the update code simpler, and I guess it would make sense to have the developer responsible of knowing whether the item factory relies on some other state. Don't hesitate to let me know which option you prefer. Thinking about it, derivedStateOf seems to make more sense, but I prefer to known your opinion before changing the code :wink:.*