### PR TITLE
Add BottomSheet with example

### DIFF
--- a/src/main/kotlin/io/github/compose4gtk/adw/components/BottomSheet.kt
+++ b/src/main/kotlin/io/github/compose4gtk/adw/components/BottomSheet.kt
@@ -25,8 +25,8 @@ fun BottomSheet(
     fullWidth: Boolean = true,
     modal: Boolean = true,
     showDragHandle: Boolean = true,
-    onOpen: (() -> Unit)? = null,
-    onClose: (() -> Unit)? = null,
+    onClose: () -> Unit = {},
+    onOpen: () -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
     sheet: @Composable () -> Unit = {},
     content: @Composable () -> Unit = {},
@@ -56,10 +56,9 @@ fun BottomSheet(
             bottomSheet.onNotify("open") {
                 val currentWidgetOpen = bottomSheet.open
                 if (currentWidgetOpen != lastOpen) {
-                    if (currentWidgetOpen && onOpen != null) {
+                    if (currentWidgetOpen) {
                         onOpen()
-                    }
-                    if (!currentWidgetOpen && onClose != null) {
+                    } else {
                         onClose()
                     }
                     bottomSheet.open = open

--- a/src/main/kotlin/io/github/compose4gtk/adw/components/BottomSheet.kt
+++ b/src/main/kotlin/io/github/compose4gtk/adw/components/BottomSheet.kt
@@ -1,0 +1,108 @@
+package io.github.compose4gtk.adw.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeNode
+import io.github.compose4gtk.GtkApplier
+import io.github.compose4gtk.GtkComposeNode
+import io.github.compose4gtk.GtkComposeWidget
+import io.github.compose4gtk.SingleChildComposeNode
+import io.github.compose4gtk.VirtualComposeNode
+import io.github.compose4gtk.VirtualComposeNodeContainer
+import io.github.compose4gtk.modifier.Modifier
+import org.gnome.adw.BottomSheet
+
+@Composable
+fun BottomSheet(
+    open: Boolean,
+    modifier: Modifier = Modifier,
+    align: Float = 0.5f,
+    canClose: Boolean = true,
+    canOpen: Boolean = true,
+    fullWidth: Boolean = true,
+    modal: Boolean = true,
+    showDragHandle: Boolean = true,
+    bottomBar: @Composable () -> Unit = {},
+    sheet: @Composable () -> Unit = {},
+    content: @Composable () -> Unit = {},
+) {
+    ComposeNode<GtkComposeWidget<BottomSheet>, GtkApplier>(
+        factory = {
+            VirtualComposeNodeContainer(BottomSheet.builder().build())
+        },
+        update = {
+            set(open) { this.widget.open = it }
+            set(modifier) { applyModifier(it) }
+            set(align) { this.widget.align = it }
+            set(canClose) { this.widget.canClose = it }
+            set(canOpen) { this.widget.canOpen = it }
+            set(fullWidth) { this.widget.fullWidth = it }
+            set(modal) { this.widget.modal = it }
+            set(showDragHandle) { this.widget.showDragHandle = it }
+        },
+        content = {
+            BottomBar {
+                bottomBar()
+            }
+            Sheet {
+                sheet()
+            }
+            Content {
+                content()
+            }
+        }
+    )
+}
+
+@Composable
+private fun BottomBar(
+    content: @Composable () -> Unit,
+) {
+    ComposeNode<GtkComposeNode, GtkApplier>(
+        factory = {
+            VirtualComposeNode<BottomSheet> { bottomSheet ->
+                SingleChildComposeNode(
+                    bottomSheet,
+                    set = { bottomBar = it },
+                )
+            }
+        },
+        update = {},
+        content = content,
+    )
+}
+
+@Composable
+private fun Sheet(
+    content: @Composable () -> Unit,
+) {
+    ComposeNode<GtkComposeNode, GtkApplier>(
+        factory = {
+            VirtualComposeNode<BottomSheet> { bottomSheet ->
+                SingleChildComposeNode(
+                    bottomSheet,
+                    set = { sheet = it },
+                )
+            }
+        },
+        update = {},
+        content = content,
+    )
+}
+
+@Composable
+private fun Content(
+    content: @Composable () -> Unit,
+) {
+    ComposeNode<GtkComposeNode, GtkApplier>(
+        factory = {
+            VirtualComposeNode<BottomSheet> { bottomSheet ->
+                SingleChildComposeNode(
+                    bottomSheet,
+                    set = { setContent(it) },
+                )
+            }
+        },
+        update = {},
+        content = content,
+    )
+}

--- a/src/test/kotlin/BottomSheet.kt
+++ b/src/test/kotlin/BottomSheet.kt
@@ -1,0 +1,107 @@
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import io.github.compose4gtk.adw.application
+import io.github.compose4gtk.adw.components.ApplicationWindow
+import io.github.compose4gtk.adw.components.BottomSheet
+import io.github.compose4gtk.adw.components.HeaderBar
+import io.github.compose4gtk.adw.components.HorizontalClamp
+import io.github.compose4gtk.adw.components.StatusPage
+import io.github.compose4gtk.gtk.components.ToggleButton
+import io.github.compose4gtk.gtk.components.VerticalBox
+import io.github.compose4gtk.modifier.Modifier
+import io.github.compose4gtk.modifier.cssClasses
+
+fun main(args: Array<String>) {
+    application("my.example.hello-app", args) {
+        ApplicationWindow(
+            title = "Bottom Sheet",
+            onClose = ::exitApplication,
+            defaultWidth = 800,
+            defaultHeight = 640,
+        ) {
+            var open by remember { mutableStateOf(false) }
+            var canClose by remember { mutableStateOf(true) }
+            var canOpen by remember { mutableStateOf(true) }
+            var fullWidth by remember { mutableStateOf(true) }
+            var modal by remember { mutableStateOf(true) }
+            var showDragHandle by remember { mutableStateOf(true) }
+
+            BottomSheet(
+                open = open,
+                canClose = canClose,
+                canOpen = canOpen,
+                fullWidth = fullWidth,
+                modal = modal,
+                showDragHandle = showDragHandle,
+                sheet = {
+                    StatusPage(
+                        title = "Sheet",
+                    ) {
+                        HorizontalClamp {
+                            VerticalBox {
+                                ToggleButton(
+                                    label = "Can Close",
+                                    active = canClose,
+                                    onToggle = {
+                                        canClose = !canClose
+                                    }
+                                )
+                                ToggleButton(
+                                    label = "Show Drag Handle",
+                                    active = showDragHandle,
+                                    onToggle = {
+                                        showDragHandle = !showDragHandle
+                                    }
+                                )
+                                ToggleButton(
+                                    label = "Modal",
+                                    active = modal,
+                                    onToggle = {
+                                        modal = !modal
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            ) {
+                VerticalBox {
+                    HeaderBar(modifier = Modifier.cssClasses("flat"))
+
+                    StatusPage(
+                        title = "Bottom Sheet",
+                        description = "Display content with a bottom sheet",
+                    ) {
+                        HorizontalClamp {
+                            VerticalBox {
+                                ToggleButton(
+                                    label = "Full Width",
+                                    active = fullWidth,
+                                    onToggle = {
+                                        fullWidth = !fullWidth
+                                    },
+                                )
+                                ToggleButton(
+                                    label = "Can Open",
+                                    active = canOpen,
+                                    onToggle = {
+                                        canOpen = !canOpen
+                                    }
+                                )
+                                ToggleButton(
+                                    label = "Open",
+                                    active = open,
+                                    onToggle = {
+                                        open = !open
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/BottomSheet.kt
+++ b/src/test/kotlin/BottomSheet.kt
@@ -8,10 +8,12 @@ import io.github.compose4gtk.adw.components.BottomSheet
 import io.github.compose4gtk.adw.components.HeaderBar
 import io.github.compose4gtk.adw.components.HorizontalClamp
 import io.github.compose4gtk.adw.components.StatusPage
+import io.github.compose4gtk.gtk.components.Label
 import io.github.compose4gtk.gtk.components.ToggleButton
 import io.github.compose4gtk.gtk.components.VerticalBox
 import io.github.compose4gtk.modifier.Modifier
 import io.github.compose4gtk.modifier.cssClasses
+import io.github.compose4gtk.modifier.margin
 
 fun main(args: Array<String>) {
     application("my.example.hello-app", args) {
@@ -35,6 +37,11 @@ fun main(args: Array<String>) {
                 fullWidth = fullWidth,
                 modal = modal,
                 showDragHandle = showDragHandle,
+                onOpen = { open = true },
+                onClose = { open = false },
+                bottomBar = {
+                    Label(text = "Bottom Sheet", modifier = Modifier.margin(8))
+                },
                 sheet = {
                     StatusPage(
                         title = "Sheet",
@@ -46,26 +53,26 @@ fun main(args: Array<String>) {
                                     active = canClose,
                                     onToggle = {
                                         canClose = !canClose
-                                    }
+                                    },
                                 )
                                 ToggleButton(
                                     label = "Show Drag Handle",
                                     active = showDragHandle,
                                     onToggle = {
                                         showDragHandle = !showDragHandle
-                                    }
+                                    },
                                 )
                                 ToggleButton(
                                     label = "Modal",
                                     active = modal,
                                     onToggle = {
                                         modal = !modal
-                                    }
+                                    },
                                 )
                             }
                         }
                     }
-                }
+                },
             ) {
                 VerticalBox {
                     HeaderBar(modifier = Modifier.cssClasses("flat"))
@@ -76,6 +83,7 @@ fun main(args: Array<String>) {
                     ) {
                         HorizontalClamp {
                             VerticalBox {
+                                Label(text = open.toString())
                                 ToggleButton(
                                     label = "Full Width",
                                     active = fullWidth,
@@ -88,14 +96,14 @@ fun main(args: Array<String>) {
                                     active = canOpen,
                                     onToggle = {
                                         canOpen = !canOpen
-                                    }
+                                    },
                                 )
                                 ToggleButton(
                                     label = "Open",
                                     active = open,
                                     onToggle = {
                                         open = !open
-                                    }
+                                    },
                                 )
                             }
                         }


### PR DESCRIPTION
This PR adds the bottom sheet component. The GTK component doesn't come with a signal when the sheet opens and closes. To work around this, I implemented `onOpen` and `onClose` in which you have to specify `open` to be `true` or `false` depending on your goal. Without these two functions, when the user would drag the sheet opened or closed the sheet's state would diverge from it's `open` value.

https://github.com/user-attachments/assets/0d680c86-a46d-4689-b753-30650ead3776

