### PR TITLE
Add Gtk.Label properties & signals

### DIFF
--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Label.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Label.kt
@@ -3,21 +3,77 @@ package io.github.compose4gtk.gtk.components
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import io.github.compose4gtk.GtkApplier
-import io.github.compose4gtk.GtkComposeWidget
 import io.github.compose4gtk.LeafComposeNode
 import io.github.compose4gtk.modifier.Modifier
+import io.github.jwharm.javagi.gobject.SignalConnection
+import org.gnome.gtk.Justification
 import org.gnome.gtk.Label
+import org.gnome.gtk.NaturalWrapMode
+import org.gnome.pango.EllipsizeMode
+import org.gnome.pango.WrapMode
 
-// TODO: all other properties
+private class GtkLabelComposeNode(gObject: Label) : LeafComposeNode<Label>(gObject) {
+    var onActivateCurrentLink: SignalConnection<Label.ActivateCurrentLinkCallback>? = null
+    var onActivateLink: SignalConnection<Label.ActivateLinkCallback>? = null
+    var onCopyClipboard: SignalConnection<Label.CopyClipboardCallback>? = null
+}
+
 @Composable
 fun Label(
     text: String,
     modifier: Modifier = Modifier,
+    // TODO - attributes
+    ellipsize: EllipsizeMode = EllipsizeMode.NONE,
+    // TODO - extra-menu
+    justify: Justification = Justification.LEFT,
+    lines: Int = -1,
+    maxWidthChars: Int = -1,
+    // TODO - mnemonic-widget
+    naturalWrapMode: NaturalWrapMode = NaturalWrapMode.INHERIT,
+    selectable: Boolean = false,
+    singleLineMode: Boolean = false,
+    // TODO - tabs
+    useMarkup: Boolean = false,
+    useUnderline: Boolean = false,
+    widthChars: Int = -1,
+    wrap: Boolean = false,
+    wrapMode: WrapMode = WrapMode.WORD,
+    xAlign: Float = .5f,
+    yAlign: Float = .5f,
+    onActivateCurrentLink: (() -> Unit)? = null,
+    onActivateLink: ((uri: String) -> Boolean)? = null,
+    onCopyClipboard: (() -> Unit)? = null,
 ) {
-    ComposeNode<GtkComposeWidget<Label>, GtkApplier>({
-        LeafComposeNode(Label.builder().build())
+    ComposeNode<GtkLabelComposeNode, GtkApplier>({
+        GtkLabelComposeNode(Label.builder().build())
     }) {
         set(modifier) { applyModifier(it) }
         set(text) { this.widget.text = it }
+        set(ellipsize) { this.widget.ellipsize = it }
+        set(justify) { this.widget.justify = it }
+        set(lines) { this.widget.lines = it }
+        set(maxWidthChars) { this.widget.maxWidthChars = it }
+        set(selectable) { this.widget.selectable = it }
+        set(naturalWrapMode) { this.widget.naturalWrapMode = it }
+        set(singleLineMode) { this.widget.singleLineMode = it }
+        set(useMarkup) { this.widget.useMarkup = it }
+        set(useUnderline) { this.widget.useUnderline = it }
+        set(widthChars) { this.widget.widthChars = it }
+        set(wrap) { this.widget.wrap = it }
+        set(wrapMode) { this.widget.wrapMode = it }
+        set(xAlign) { this.widget.xalign = it }
+        set(yAlign) { this.widget.yalign = it }
+        set(onActivateCurrentLink) {
+            this.onActivateCurrentLink?.disconnect()
+            onActivateCurrentLink?.let { this.widget.onActivateCurrentLink(onActivateCurrentLink) }
+        }
+        set(onActivateLink) {
+            this.onActivateLink?.disconnect()
+            onActivateLink?.let { this.widget.onActivateLink(onActivateLink) }
+        }
+        set(onCopyClipboard) {
+            this.onCopyClipboard?.disconnect()
+            onCopyClipboard?.let { this.widget.onCopyClipboard(onCopyClipboard) }
+        }
     }
 }

--- a/lib/src/test/kotlin/Label.kt
+++ b/lib/src/test/kotlin/Label.kt
@@ -1,0 +1,144 @@
+import androidx.compose.runtime.Composable
+import io.github.compose4gtk.adw.adwApplication
+import io.github.compose4gtk.adw.components.ApplicationWindow
+import io.github.compose4gtk.adw.components.HeaderBar
+import io.github.compose4gtk.gtk.components.Box
+import io.github.compose4gtk.gtk.components.Label
+import io.github.compose4gtk.gtk.components.VerticalBox
+import io.github.compose4gtk.modifier.Modifier
+import io.github.compose4gtk.modifier.alignment
+import io.github.compose4gtk.modifier.cssClasses
+import io.github.compose4gtk.modifier.margin
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.gnome.gtk.Align
+import org.gnome.gtk.Justification
+import org.gnome.gtk.Orientation
+import org.gnome.pango.EllipsizeMode
+
+private val logger = KotlinLogging.logger {}
+
+fun main(args: Array<String>) {
+    adwApplication("my.example.hello-app", args) {
+        ApplicationWindow("Test", onClose = ::exitApplication, defaultWidth = 100, defaultHeight = 100) {
+            Box(orientation = Orientation.VERTICAL) {
+                HeaderBar()
+
+                Card("Markup") {
+                    Label(
+                        "Some text with <b>basic</b> <i>format</i>",
+                        useMarkup = true,
+                        modifier = Modifier
+                            .alignment(Align.START),
+                    )
+                    Label(
+                        "Internally handled <a href=\"http://example.org\">link</a>.",
+                        onActivateLink = { uri ->
+                            logger.info { "link clicked: $uri" }
+                            true
+                        },
+                        useMarkup = true,
+                        modifier = Modifier
+                            .alignment(Align.START),
+                    )
+                    Label(
+                        "Externally handled <a href=\"http://example.org\">link</a>.",
+                        onActivateLink = { uri ->
+                            logger.info { "link clicked: $uri" }
+                            false
+                        },
+                        useMarkup = true,
+                        modifier = Modifier
+                            .alignment(Align.START),
+                    )
+                }
+
+                Card("Selectable text") {
+                    Label(
+                        "Some text that can be selected and copied",
+                        selectable = true,
+                        onCopyClipboard = { println("copied") },
+                    )
+                }
+
+                Card("Ellipsize") {
+                    Label(
+                        "Some long text we want to ellipsize",
+                        modifier = Modifier
+                            .alignment(Align.START),
+                    )
+                    Label(
+                        "Some long text we want to ellipsize",
+                        maxWidthChars = 20,
+                        ellipsize = EllipsizeMode.START,
+                        modifier = Modifier
+                            .alignment(Align.START),
+                    )
+                    Label(
+                        "Some long text we want to ellipsize",
+                        maxWidthChars = 20,
+                        ellipsize = EllipsizeMode.MIDDLE,
+                        modifier = Modifier
+                            .alignment(Align.START),
+                    )
+                    Label(
+                        "Some long text we want to ellipsize",
+                        maxWidthChars = 20,
+                        ellipsize = EllipsizeMode.END,
+                        modifier = Modifier
+                            .alignment(Align.START),
+                    )
+                }
+
+                Card("Justification") {
+                    Label(
+                        "Left justification, sample text: lorem ipsum dolor sit amet.",
+                        wrap = true,
+                        justify = Justification.LEFT,
+                    )
+                    Label(
+                        "Center justification, sample text: lorem ipsum dolor sit amet.",
+                        wrap = true,
+                        justify = Justification.CENTER,
+                    )
+                    Label(
+                        "Right justification, sample text: lorem ipsum dolor sit amet.",
+                        wrap = true,
+                        justify = Justification.RIGHT,
+                    )
+                    Label(
+                        "Fill justification, sample text: lorem ipsum dolor sit amet.",
+                        wrap = true,
+                        justify = Justification.FILL,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Card(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    VerticalBox(
+        modifier = Modifier
+            .margin(16),
+        spacing = 16,
+    ) {
+        Label(title)
+
+        Box(
+            modifier = Modifier
+                .cssClasses(listOf("card")),
+        ) {
+            VerticalBox(
+                spacing = 16,
+                modifier = Modifier
+                    .margin(16),
+            ) {
+                content()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added the most trivial properties, left out a few less trivial props for now (added todos for those).
Also added signal handlers & a test page.

Test output:
![Capture d’écran du 2025-06-02 15-20-04](https://github.com/user-attachments/assets/379102fe-5054-4002-80a4-39bd18e1218a)
