### PR TITLE
Remove unnecessary toList() call on Gtk.Scale

### DIFF
--- a/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Scale.kt
+++ b/lib/src/main/kotlin/io/github/compose4gtk/gtk/components/Scale.kt
@@ -60,7 +60,7 @@ fun Scale(
             set(pageIncrements) { this.widget.adjustment.pageIncrement = it }
             set(inverted) { this.widget.inverted = it }
             set(showFillLevel) { this.widget.showFillLevel = it }
-            set(marks.toList()) {
+            set(marks) {
                 this.widget.clearMarks()
                 for (mark in marks) {
                     this.widget.addMark(mark.value, mark.position, mark.markup)

--- a/lib/src/test/kotlin/Scale.kt
+++ b/lib/src/test/kotlin/Scale.kt
@@ -58,7 +58,7 @@ fun main(args: Array<String>) {
                                 stepIncrements = 10.0,
                                 pageIncrements = 25.0,
                                 showFillLevel = true,
-                                marks = marks,
+                                marks = marks.toList(),
                             )
 
                             HorizontalBox(


### PR DESCRIPTION
I removed the toList() call from the component like what was done in Gtk.LevelBar