### PR TITLE
Add onSelectionChanges to ListView

### DIFF
--- a/lib/src/test/kotlin/ListView.kt
+++ b/lib/src/test/kotlin/ListView.kt
@@ -40,6 +40,11 @@ fun main(args: Array<String>) {
                             ListView(
                                 items = itemSize,
                                 selectionMode = SelectionMode.Single,
+                                onSelectionChanges = {
+                                    for (position in it) {
+                                        println("Selected: ${items[position].name}")
+                                    }
+                                },
                                 onActivate = { position -> logger.info { "activated item #$position" } },
                             ) { index ->
                                 Label("Item #$index")
@@ -48,6 +53,11 @@ fun main(args: Array<String>) {
                         Panel("Custom model (multiple selection)") {
                             ListView(
                                 model = rememberMultiSelectionModel(items),
+                                onSelectionChanges = {
+                                    for (position in it) {
+                                        println("Selected: ${items[position].name}")
+                                    }
+                                },
                                 onActivate = { position -> logger.info { "activated item #$position" } },
                             ) { customItem ->
                                 Label(customItem.name)


### PR DESCRIPTION
Adds a callback that is triggered every time the selection changes. The callback returns an array of positions in case multiple items are selected. This is a function that is associated with the selection model itself but I thought it was a nice feature and perhaps a necessary one as well for declarative UIs. Also, declarative UI libraries usually provide a way to control the selected item as well. For example: [Mui's Select](https://mui.com/material-ui/react-select/). Here the selected value is provided and changed in the callback. Would it be a good idea for me to implement this here?